### PR TITLE
Fix 2FA wiki page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To configure this plugin please review the following options:
 | hass_topic | The default Hass.io availability topic, used to monitor for Hass.io restarts to republish device state.  Should rarely be changed. |
 | mqtt_user | Username for MQTT broker (default for Mosquitto addon is to use HA username/password) |
 | mqtt_pass | Password for MQTT broker (default for Mosquitto addon is to use HA username/password) |
-| ring_token | The refresh token received after authenticating with 2FA - See https://github.com/dgreif/ring/wiki/Two-Factor-Auth |
+| ring_token | The refresh token received after authenticating with 2FA - See https://github.com/dgreif/ring/wiki/Refresh-Tokens |
 | enable_cameras | Default false since the native Ring component for Home Assistant supports these, set to true to use camera support in this addon |
 | location_ids | Comma separated list of location Ids to limit devices.  Blank is all locations which the specified account has access to. |
 


### PR DESCRIPTION
The previous link (https://github.com/dgreif/ring/wiki/Two-Factor-Auth) results in the creation of a new wiki page, meaning that it does not exist. There is a another resource, similar to "Two-Factor Auth", called "Refresh Tokens". I've updated the README with this new link (https://github.com/dgreif/ring/wiki/Refresh-Tokens).